### PR TITLE
add M_PI definition

### DIFF
--- a/src/core/system.cpp
+++ b/src/core/system.cpp
@@ -42,7 +42,9 @@ using namespace pteros;
 using namespace Eigen;
 using namespace fmt;
 
-
+#ifndef M_PI
+    #define M_PI 3.14159265358979323846
+#endif
 
 // Base constructor of the system class
 System::System() {


### PR DESCRIPTION
Fix compilation on mingw. Math Constants are not defined in Standard C/C++.