### PR TITLE
Fix compilation on gcc 8.1

### DIFF
--- a/include/pteros/core/logging.h
+++ b/include/pteros/core/logging.h
@@ -30,6 +30,7 @@
 
 #include "spdlog/spdlog.h"
 #include "spdlog/fmt/ostr.h"
+#include "spdlog/sinks/stdout_sinks.h"
 #include <iostream>
 
 namespace pteros {


### PR DESCRIPTION
Resolves #9. spdlog/sinks/stdout_sinks.h must be included explicitly on gcc 8.1