### PR TITLE
Fix a memory leak in peglib

### DIFF
--- a/src/core/selection_parser/peglib.h
+++ b/src/core/selection_parser/peglib.h
@@ -2237,7 +2237,7 @@ struct AstBase : public Annotation
     const std::string                 token;
 
     std::vector<std::shared_ptr<AstBase<Annotation>>> nodes;
-    std::shared_ptr<AstBase<Annotation>>              parent;
+    std::weak_ptr<AstBase<Annotation>>              parent;
 };
 
 template <typename T>


### PR DESCRIPTION
This backports the commit  #38d4897 of yhirose/cpp-peglib upstream.
Fix #20